### PR TITLE
Fix testing for tag

### DIFF
--- a/tests/Tags/WebmentionsTest.php
+++ b/tests/Tags/WebmentionsTest.php
@@ -2,12 +2,38 @@
 
 namespace Astrotomic\Webmentions\Statamic\Tests\Tags;
 
+use Astrotomic\Webmentions\Statamic\Tags\Webmentions;
 use Astrotomic\Webmentions\Statamic\Tests\TestCase;
 use Illuminate\Http\Request;
 
 class WebmentionsTest extends TestCase
 {
+    protected Webmentions $tag;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->tag = new Webmentions();
+        $this->tag->setContext(['webmentions']);
+    }
+
     /** @test */
+    public function it_is_registered(): void
+    {
+        $this->assertTrue(isset(app()['statamic.tags']['webmentions']));
+    }
+
+    /** @test */
+    public function it_gets_webmentions_for_url(): void
+    {
+        $url = 'https://gummibeer.dev/blog/2020/human-readable-intervals/';
+
+        // Passing the url for the {{ webmentions url="" }} tag
+        $this->tag->setParameters(['url' => $url]);
+
+        $this->assertEquals($url, $this->tag->index()->first()->target);
+    }
+
     public function it_gets_webmentions_by_current_request(): void
     {
         $request = Request::create('https://gummibeer.dev/blog/2020/human-readable-intervals/', 'GET');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Astrotomic\Webmentions\Statamic\WebmentionsStatamicServiceProvider;
 use Astrotomic\Webmentions\WebmentionsServiceProvider;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Statamic\Extend\Manifest;
 use Statamic\Facades\Antlers;
 use Statamic\Providers\StatamicServiceProvider;
 
@@ -17,6 +18,18 @@ abstract class TestCase extends OrchestraTestCase
             StatamicServiceProvider::class,
             WebmentionsServiceProvider::class,
             WebmentionsStatamicServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->make(Manifest::class)->manifest = [
+            'astrotomic/statamic-webmentions' => [
+                'id'        => 'astrotomic/statamic-webmentions',
+                'namespace' => 'Astrotomic\\Webmentions\\Statamic\\',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR registers the environment correctly for unit testing the `{{ webmentions }}` tag. It adds two tests for

* Checking that the tag is available to Statamic
* Check that the `{{ webmentions url=".." }}` (index method) returns a proper response